### PR TITLE
Added loadgen to contained_files - part of https://github.com/krai/axs2mlperf/pull/31#discussion_r1406108328

### DIFF
--- a/core_collection/workflows_collection/mlperf_inference_git_recipe/data_axs.json
+++ b/core_collection/workflows_collection/mlperf_inference_git_recipe/data_axs.json
@@ -14,6 +14,7 @@
     "contained_files": {
         "mlperf_conf_file": [ "mlperf.conf" ],
 
+        "loadgen": [ "loadgen" ],
         "vision_tools_dir": [ "vision", "classification_and_detection", "tools" ],
         "classification_accuracy_script": [ "vision", "classification_and_detection", "tools", "accuracy-imagenet.py" ],
         "coco_detection_accuracy_script": [ "vision", "classification_and_detection", "tools", "accuracy-coco.py" ],


### PR DESCRIPTION
This just allows us to use get_path_of loadgen, rather than relying on loadgen being at a specific position