### PR TITLE
Added the ability to throw errors from axs

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -10,11 +10,12 @@ else:
     from kernel import default as ak
 """
 
-__version__ = '0.2.343'     # TODO: update with every kernel change
+__version__ = '0.2.344'     # TODO: update with every kernel change
 
 import logging
 import os
 import sys
+
 from runnable import Runnable
 from stored_entry import Entry
 

--- a/runnable.py
+++ b/runnable.py
@@ -4,11 +4,12 @@ import inspect
 import logging
 import re
 import sys
-
-import ufun
-import function_access
-from param_source import ParamSource
 from copy import deepcopy
+
+import function_access
+import ufun
+from param_source import ParamSource
+
 
 class Runnable(ParamSource):
     """An object of Runnable class is a non-persistent container of parameters (inherited) and code (own)
@@ -614,6 +615,15 @@ Usage examples :
         else:
             return input_structure                                                          # basement step
 
+    def throw(self, error_message, exception_class="Exception"): # TODO: Is it possible to find out the field name? E.g. "v"
+        """Throw an error
+Usage examples :
+                "x": [ "^^", "throw", "Override this" ]
+                "y": [ "^^", "throw", "Override this", "FileNotFoundError" ]
+        """
+        logging.error(f"Raising exception: {exception_class}({error_message})")
+        exception_class = eval(exception_class)
+        raise exception_class(error_message)
 
 def plus_one(number):
     "Adds 1 to the argument"

--- a/stored_entry.py
+++ b/stored_entry.py
@@ -354,6 +354,24 @@ Usage examples :
             logging.warning(f"[{self.get_name()}] was not stored in the file system, so cannot be removed")
 
         return self
+    
+        
+    def throw(self, error: str): # TODO: Is it possible to find out the field name? E.g. "v"
+        """Throw an error
+Usage examples :
+                "v": [ "^^", "throw", "Override this" ]
+        """
+        logging.error(error)
+        raise Exception(error)
+    
+    def throw_if_none(self, val, error):
+        """Throw an error if the value is none, else return the value
+Usage examples :
+                axs byname maybe_entry , throw_if_none "maybe_entry doesn't exist" , remove
+        """
+        if val is None:
+            self.throw(error)
+        return val
 
 
 if __name__ == '__main__':

--- a/stored_entry.py
+++ b/stored_entry.py
@@ -354,16 +354,6 @@ Usage examples :
             logging.warning(f"[{self.get_name()}] was not stored in the file system, so cannot be removed")
 
         return self
-    
-    def throw_if_none(self, val, error):
-        """Throw an error if the value is none, else return the value
-Usage examples :
-                axs byname maybe_entry , throw_if_none "maybe_entry doesn't exist" , remove
-        """
-        if val is None:
-            self.throw(error)
-        return val
-
 
 if __name__ == '__main__':
 

--- a/stored_entry.py
+++ b/stored_entry.py
@@ -355,15 +355,6 @@ Usage examples :
 
         return self
     
-        
-    def throw(self, error: str): # TODO: Is it possible to find out the field name? E.g. "v"
-        """Throw an error
-Usage examples :
-                "v": [ "^^", "throw", "Override this" ]
-        """
-        logging.error(error)
-        raise Exception(error)
-    
     def throw_if_none(self, val, error):
         """Throw an error if the value is none, else return the value
 Usage examples :


### PR DESCRIPTION
A lot of times recipes fail because something somewhere doesn't exist, when it should. These failures show up downstream of the actual problem, making it hard to debug. With these changes someone can assert that certain entries or other values must exist, and if they don't then the program execution will terminate immediately at that location. Hopefully it'll make it easier to debug